### PR TITLE
Feat/#58 landing page layout: 랜딩페이지 레이아웃 구성 완료

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,7 +1,13 @@
-import React from "react";
+import AlertBanner from "@/components/landing/AlertBanner";
+import MapPreview from "@/components/landing/MapPreview";
 
-const LandingPage = () => {
-  return <div>Landing LandingPage</div>;
-};
 
-export default LandingPage;
+export default function HomePage() {
+  return (
+    <main className="px-4 py-6 space-y-8">
+      <AlertBanner />
+      <MapPreview />
+      
+    </main>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,13 +1,16 @@
 import AlertBanner from "@/components/landing/AlertBanner";
 import MapPreview from "@/components/landing/MapPreview";
-
+import LandingBanner from "@/components/landing/BannerSection";
 
 export default function HomePage() {
   return (
     <main className="px-4 py-6 space-y-8">
+      <>상단 배너</>
       <AlertBanner />
+      <>지도 미리보기 클릭시 = map페이지로 이동</>
       <MapPreview />
-      
+      <p>배너섹션 = 재난안전포털 외부 url 연결</p>
+      <LandingBanner />
     </main>
   );
 }

--- a/src/components/landing/AlertBanner.tsx
+++ b/src/components/landing/AlertBanner.tsx
@@ -1,0 +1,17 @@
+'use client';
+
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert"
+import { AlertTriangle } from "lucide-react"
+
+const AlertBanner = () => {
+
+    return (
+        <Alert variant="destructive" >
+            <AlertTriangle />
+            <AlertTitle>[지진] 서울 강서구 규모 4.0 지진 발생</AlertTitle>
+            <AlertDescription>부가 설명</AlertDescription>
+        </Alert>
+    )
+}
+
+export default AlertBanner

--- a/src/components/landing/BannerSection.tsx
+++ b/src/components/landing/BannerSection.tsx
@@ -11,7 +11,7 @@ export default function LandingBanner() {
     <section className="relative w-full h-[300px] bg-blue-300 flex flex-col justify-center items-center text-center px-4">
       <h1 className="text-3xl font-bold mb-2">빠르고 안전한 대피소 찾기</h1>
       <p>근처의 재난 대피소 정보를 한눈에 확인하세요</p>
-      <Button onClick={handleExternalLink} className="text-white bg-blue-600 hover:bg-blue-700">
+      <Button onClick={handleExternalLink} className="text-white bg-blue-600">
         재난안전포털 바로가기
       </Button>
     </section>

--- a/src/components/landing/BannerSection.tsx
+++ b/src/components/landing/BannerSection.tsx
@@ -1,0 +1,19 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+
+export default function LandingBanner() {
+  const handleExternalLink = () => {
+    window.open("https://www.safekorea.go.kr", "_blank"); // 외부 URL을 새 창에서 열기
+  };
+
+  return (
+    <section className="relative w-full h-[300px] bg-blue-300 flex flex-col justify-center items-center text-center px-4">
+      <h1 className="text-3xl font-bold mb-2">빠르고 안전한 대피소 찾기</h1>
+      <p>근처의 재난 대피소 정보를 한눈에 확인하세요</p>
+      <Button onClick={handleExternalLink} className="text-white bg-blue-600 hover:bg-blue-700">
+        재난안전포털 바로가기
+      </Button>
+    </section>
+  );
+}

--- a/src/components/landing/MapPreview.tsx
+++ b/src/components/landing/MapPreview.tsx
@@ -13,7 +13,7 @@ export default function LandingMapPreview() {
   return (
     <Card
       onClick={handleClick}
-      className="w-full h-56 bg-muted flex items-center justify-center rounded-lg cursor-pointer hover:opacity-90 transition"
+      className="w-full h-56 flex items-center justify-center rounded-lg transition"
     >
     </Card>
   );

--- a/src/components/landing/MapPreview.tsx
+++ b/src/components/landing/MapPreview.tsx
@@ -1,0 +1,20 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { Card } from "@/components/ui/card";
+
+export default function LandingMapPreview() {
+  const router = useRouter();
+
+  const handleClick = () => {
+    router.push("/map");
+  };
+
+  return (
+    <Card
+      onClick={handleClick}
+      className="w-full h-56 bg-muted flex items-center justify-center rounded-lg cursor-pointer hover:opacity-90 transition"
+    >
+    </Card>
+  );
+}

--- a/src/components/ui/alert.tsx
+++ b/src/components/ui/alert.tsx
@@ -1,0 +1,66 @@
+import * as React from "react"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/lib/utils"
+
+const alertVariants = cva(
+  "relative w-full rounded-lg border px-4 py-3 text-sm grid has-[>svg]:grid-cols-[calc(var(--spacing)*4)_1fr] grid-cols-[0_1fr] has-[>svg]:gap-x-3 gap-y-0.5 items-start [&>svg]:size-4 [&>svg]:translate-y-0.5 [&>svg]:text-current",
+  {
+    variants: {
+      variant: {
+        default: "bg-card text-card-foreground",
+        destructive:
+          "text-destructive bg-card [&>svg]:text-current *:data-[slot=alert-description]:text-destructive/90",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  }
+)
+
+function Alert({
+  className,
+  variant,
+  ...props
+}: React.ComponentProps<"div"> & VariantProps<typeof alertVariants>) {
+  return (
+    <div
+      data-slot="alert"
+      role="alert"
+      className={cn(alertVariants({ variant }), className)}
+      {...props}
+    />
+  )
+}
+
+function AlertTitle({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-title"
+      className={cn(
+        "col-start-2 line-clamp-1 min-h-4 font-medium tracking-tight",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AlertDescription({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-description"
+      className={cn(
+        "text-muted-foreground col-start-2 grid justify-items-start gap-1 text-sm [&_p]:leading-relaxed",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export { Alert, AlertTitle, AlertDescription }


### PR DESCRIPTION
## 💡 이슈 번호
> #58 

<br>

## 📜 작업 설명
> 랜딩 페이지 각 섹션 나눠서 레이아웃 구성

<br>

## 🖼️ 미리보기
<img width="324" alt="스크린샷 2025-04-08 오후 4 41 03" src="https://github.com/user-attachments/assets/a38a41af-bea8-4da1-8277-994a6e076442" />

<br>

## 📜 PR 유형
> 작업한 내용 확인 및 체크

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [x] CSS 등 사용자 UI 디자인 변경
- [x] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

<br>

## 🙋 리뷰 요구 사항
지도는 록기님 브렌치 병합 완료 후에 넣겠습니다!

<br>

## ❗ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.  Commit message convention 참고  (Ctrl  + 클릭하세요.) 
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
