### PR TITLE
OAuth 오류수정 및 리팩토링 최종 완료

### DIFF
--- a/src/app/(pages)/auth/auth-code-error/page.tsx
+++ b/src/app/(pages)/auth/auth-code-error/page.tsx
@@ -1,0 +1,12 @@
+const AuthCodeErrorPage = () => {
+    return (
+      <div className="flex h-screen items-center justify-center text-center p-6">
+        <div>
+          <h1 className="text-2xl font-bold mb-2">인증 중 오류가 발생했습니다</h1>
+          <p className="text-gray-500">다시 로그인하거나 문제가 계속되면 관리자에게 문의해주세요.</p>
+        </div>
+      </div>
+    );
+  };
+  
+  export default AuthCodeErrorPage;

--- a/src/app/(pages)/auth/callback/page.tsx
+++ b/src/app/(pages)/auth/callback/page.tsx
@@ -1,43 +1,66 @@
-import { redirect } from "next/navigation";
-import createSC from "@/supabase/server";
+"use client";
 
-const CallbackPage = async () => {
-  const supabase = await createSC();
+import { useEffect } from "react";
+import { useRouter } from "next/navigation";
+import createClient from "@/supabase/client";
 
-  const {
-    data: { user },
-    error,
-  } = await supabase.auth.getUser();
+const CallbackPage = () => {
+  const router = useRouter();
+  const supabase = createClient();
 
-  if (error || !user) {
-    console.error("세션 없음 또는 인증 실패", error);
-    redirect("/auth/auth-code-error");
-  }
+  useEffect(() => {
+    const handleCallback = async () => {
+      // Supabase 세션 가져오기
+      const { data: { session }, error } = await supabase.auth.getSession();
 
-  // users 테이블 조회
-  const { data: existingUser } = await supabase
-    .from("users")
-    .select("nickname")
-    .eq("id", user.id)
-    .maybeSingle();
+      // 유저 정보 확인
+      const user = session?.user;
+      if (error || !user) {
+        console.error("세션 없음 또는 인증 실패", error);
+        router.replace("/auth/auth-code-error");
+        return;
+      }
 
-  // 유저 없으면 자동 삽입
-  if (!existingUser) {
-    const { error: insertError } = await supabase.from("users").insert({
-      id: user.id,
-      nickname: "",
-    });
+      // users 테이블에서 현재 유저 조회
+      const { data: existingUser, error: fetchError } = await supabase
+        .from("users")
+        .select("nickname")
+        .eq("id", user.id)
+        .maybeSingle();
 
-    if (insertError) {
-      console.error("유저 삽입 실패", insertError);
-      redirect("/auth/auth-code-error");
-    }
+      if (fetchError) {
+        console.error("유저 조회 실패", fetchError);
+        router.replace("/auth/auth-code-error");
+        return;
+      }
 
-    redirect("/auth/nickname");
-  }
+      // 유저가 없으면 users 테이블에 신규 삽입
+      if (!existingUser) {
+        const { error: insertError } = await supabase.from("users").insert({
+          id: user.id,
+          nickname: "",
+        });
 
-  // 닉네임 여부에 따라 라우팅
-  redirect(existingUser.nickname ? "/" : "/auth/nickname");
+        if (insertError) {
+          console.error("유저 삽입 실패", insertError);
+          router.replace("/auth/auth-code-error");
+          return;
+        }
+
+        // 닉네임 등록 페이지로 이동
+        router.replace("/auth/nickname");
+        return;
+      }
+
+      // 닉네임 존재 여부에 따라 홈 또는 닉네임 등록 페이지로 이동
+      router.replace(existingUser.nickname ? "/" : "/auth/nickname");
+    };
+
+    // useEffect 내부에서 비동기 함수 실행
+    handleCallback();
+  }, [router, supabase]);
+
+  return <div className="p-6 text-center">로그인 처리 중...</div>;
 };
 
 export default CallbackPage;

--- a/src/app/(pages)/auth/callback/page.tsx
+++ b/src/app/(pages)/auth/callback/page.tsx
@@ -1,64 +1,70 @@
 "use client";
 
-import { useEffect } from "react";
 import { useRouter } from "next/navigation";
+import { useMutation } from "@tanstack/react-query";
 import createClient from "@/supabase/client";
+import { useEffect } from "react";
 
 const CallbackPage = () => {
   const router = useRouter();
   const supabase = createClient();
 
-  useEffect(() => {
-    const handleCallback = async () => {
-      // Supabase 세션 가져오기
-      const { data: { session }, error } = await supabase.auth.getSession();
-
-      // 유저 정보 확인
+  // 소셜 로그인 후 콜백 처리를 위한 mutation 정의
+  const { mutate: handleCallback } = useMutation({
+    mutationFn: async () => {
+      // 세션에서 로그인된 유저 정보 가져오기
+      const {
+        data: { session },
+        error,
+      } = await supabase.auth.getSession();
       const user = session?.user;
-      if (error || !user) {
-        console.error("세션 없음 또는 인증 실패", error);
-        router.replace("/auth/auth-code-error");
-        return;
-      }
 
-      // users 테이블에서 현재 유저 조회
+      // 인증 에러 처리
+      if (error || !user) throw new Error("인증 실패");
+
+      // users 테이블에서 해당 유저의 nickname을 조회
       const { data: existingUser, error: fetchError } = await supabase
         .from("users")
         .select("nickname")
         .eq("id", user.id)
         .maybeSingle();
 
-      if (fetchError) {
-        console.error("유저 조회 실패", fetchError);
-        router.replace("/auth/auth-code-error");
-        return;
-      }
+      // 유저 조회 실패 에러 처리
+      if (fetchError) throw new Error("유저 조회 실패");
 
-      // 유저가 없으면 users 테이블에 신규 삽입
+      // 유저 정보가 존재하지 않으면 새로 삽입
       if (!existingUser) {
         const { error: insertError } = await supabase.from("users").insert({
           id: user.id,
           nickname: "",
         });
 
-        if (insertError) {
-          console.error("유저 삽입 실패", insertError);
-          router.replace("/auth/auth-code-error");
-          return;
-        }
+        // 정보 삽입 실패 에러 처리
+        if (insertError) throw new Error("유저 정보 실패");
 
-        // 닉네임 등록 페이지로 이동
-        router.replace("/auth/nickname");
-        return;
+        // 삽입 완료 후 닉네임 등록 페이지로 이동
+        return { redirectTo: "/auth/nickname" };
       }
 
-      // 닉네임 존재 여부에 따라 홈 또는 닉네임 등록 페이지로 이동
-      router.replace(existingUser.nickname ? "/" : "/auth/nickname");
-    };
+      // 기존 유저가 존재하면 닉네임 유무에 따라 라우팅 (랜딩/닉네임)
+      return { redirectTo: existingUser.nickname ? "/" : "/auth/nickname" };
+    },
 
-    // useEffect 내부에서 비동기 함수 실행
-    handleCallback();
-  }, [router, supabase]);
+    // 인증 성공 시 지정된 경로로 이동
+    onSuccess: ({ redirectTo }) => {
+      router.replace(redirectTo);
+    },
+
+    // 인증 실패 시 에러 안내 페이지로 이동
+    onError: () => {
+      router.replace("/auth/auth-code-error");
+    },
+  });
+
+  // 컴포넌트가 처음 마운트 될 때 콜백 처리
+  useEffect(() => {
+    handleCallback(); // 최초 진입 시!
+  }, [handleCallback]);
 
   return <div className="p-6 text-center">로그인 처리 중...</div>;
 };

--- a/src/app/(pages)/auth/nickname/page.tsx
+++ b/src/app/(pages)/auth/nickname/page.tsx
@@ -1,36 +1,28 @@
-"use client";
-
-import { useEffect, useState } from "react";
+import { redirect } from "next/navigation";
+import createSC from "@/supabase/server";
 import NicknameForm from "@/components/auth/NicknameForm";
-import createClient from "@/supabase/client";
 
-const NicknamePage = () => {
-  const [userId, setUserId] = useState<string | null>(null);
+const NicknamePage = async () => {
+  const supabase = await createSC();
 
-  useEffect(() => {
-    const fetchUser = async () => {
-      const supabase = createClient();
-      const { data: { user }, error } = await supabase.auth.getUser();
+  // 세션 에서 사용자 정보 가져오기
+  const {
+    data: { user },
+    error,
+  } = await supabase.auth.getUser();
 
-      if (error) {
-        console.error("유저 정보 가져오기 실패:", error.message);
-        return;
-      }
-
-      if (user) {
-        setUserId(user.id);
-      }
-    };
-
-    fetchUser();
-  }, []);
+  if (error || !user) {
+    console.error("세션 없음 또는 인증 실패:", error?.message);
+    // 인증 실패 시 리디렉트
+    redirect("/auth/auth-code-error");
+  }
 
   return (
     <div className="p-6">
       <h1 className="mb-4 text-2xl font-semibold">닉네임 등록</h1>
-      {userId ? <NicknameForm userId={userId} /> : <p>세션 확인 중...</p>}
+      <NicknameForm userId={user.id} />
     </div>
   );
-}
+};
 
 export default NicknamePage;

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,11 +2,13 @@ import AlertBanner from "@/components/landing/AlertBanner";
 import MapPreview from "@/components/landing/MapPreview";
 import LandingBanner from "@/components/landing/BannerSection";
 import SigninDrawer from "@/components/auth/SigninDrawer";
+import LogoutButton from "@/components/auth/LogoutButton";
 
 const HomePage = () => {
   return (
     <main className="px-4 py-6 space-y-8">
       <SigninDrawer />
+      <LogoutButton />
       <>상단 배너</>
       <AlertBanner />
       <>지도 미리보기 클릭시 = map페이지로 이동</>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,10 +1,12 @@
 import AlertBanner from "@/components/landing/AlertBanner";
 import MapPreview from "@/components/landing/MapPreview";
 import LandingBanner from "@/components/landing/BannerSection";
+import SigninDrawer from "@/components/auth/SigninDrawer";
 
 const HomePage = () => {
   return (
     <main className="px-4 py-6 space-y-8">
+      <SigninDrawer />
       <>상단 배너</>
       <AlertBanner />
       <>지도 미리보기 클릭시 = map페이지로 이동</>

--- a/src/components/auth/LogoutButton.tsx
+++ b/src/components/auth/LogoutButton.tsx
@@ -4,6 +4,7 @@ import { useRouter } from "next/navigation";
 import { Button } from "../ui/button";
 import createClient from "@/supabase/client";
 import PATH from "@/constants/PATH";
+import { toast } from "sonner";
 
 const LogoutButton = () => {
   const router = useRouter();
@@ -15,6 +16,7 @@ const LogoutButton = () => {
       console.error("로그아웃 실패:", error.message);
       return;
     }
+    toast.success("로그아웃 성공");
     router.push(PATH.HOME); // 로그아웃 후에 랜딩페이지로 이동
   };
   return <Button onClick={handleLogout}>로그아웃</Button>;

--- a/src/components/auth/NicknameForm.tsx
+++ b/src/components/auth/NicknameForm.tsx
@@ -16,6 +16,7 @@ import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import createClient from "@/supabase/client";
 import PATH from "@/constants/PATH";
+import { toast } from "sonner";
 
 const formSchema = z.object({
   nickname: z
@@ -50,8 +51,9 @@ const NicknameForm = ({ userId }: { userId: string }) => {
     });
 
     if (dbError) {
-      alert("닉네임 저장 실패");
+      toast.error("닉네임 저장 실패");
     } else {
+      toast.success("닉네임 저장 완료");
       router.push(PATH.HOME);
     }
   };

--- a/src/components/auth/NicknameForm.tsx
+++ b/src/components/auth/NicknameForm.tsx
@@ -44,7 +44,7 @@ const NicknameForm = ({ userId }: { userId: string }) => {
   const onSubmit = async (data: FormData) => {
     const supabase = createClient();
 
-    const { error: dbError } = await supabase.from("users").insert({
+    const { error: dbError } = await supabase.from("users").upsert({
       id: userId,
       nickname: data.nickname,
     });

--- a/src/components/auth/NicknameForm.tsx
+++ b/src/components/auth/NicknameForm.tsx
@@ -77,7 +77,7 @@ const NicknameForm = ({ userId }: { userId: string }) => {
           )}
         />
         <Button type="submit" disabled={isSubmitting}>
-          {isSubmitting ? "등록 중..." : "닉네임 + 프로필 저장"}
+          {isSubmitting ? "등록 중..." : "저장하기"}
         </Button>
       </form>
     </Form>


### PR DESCRIPTION
## 💡 이슈 번호
#128 

<br>

## 📜 작업 설명
- callback 페이지 신규유저 로직 개선
- nickname form에서 사용자 정보 삽입 로직 개선
- 알림처리 sonner로 개선
- 로그아웃 버튼에도 sonner 적용
- 인증 에러 페이지 추가
- callbackpage api함수 로직 변경 및 비동기 처리 개선
- 닉네임 페이지 서버컴포넌트로 개선
- 랜딩 페이지에 테스트용 로그인/로그아웃 버튼 추가(임시)
- 지금 구조처럼 “유저 인증 상태 확인 → 조건 분기 → 삽입 또는 라우팅” 처럼
복합적인 동작이 필요하기 때문에 수동으로 실행하는 useMutation() 사용
<br>

##  참고 자료

- [관련 트러블 슈팅 - Supabase OAuth 인증 트러블슈팅](https://velog.io/@33hyun/Supabase-OAuth-인증-트러블슈팅)
<br>

## 🖼️ 미리보기

<img width="329" alt="스크린샷 2025-04-14 오후 2 03 15" src="https://github.com/user-attachments/assets/07e7ba3c-2118-45e1-b1b1-93fceb2ca85a" />
<img width="323" alt="스크린샷 2025-04-14 오후 2 03 49" src="https://github.com/user-attachments/assets/2058da7e-7cd1-4ac8-a048-5bfd7c90fbba" />
<br>
`users` 테이블에 정상 삽입 되는 모습
<img width="1109" alt="스크린샷 2025-04-14 오후 2 04 27" src="https://github.com/user-attachments/assets/616904c9-5f3a-4892-aba7-6181ccdebd40" />




<br>

## 📜 PR 유형
작업한 내용 확인 및 체크

- [x] 새로운 기능 추가
- [x] 버그 수정
- [x] CSS 등 사용자 UI 디자인 변경
- [x] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [x] 주석 추가 및 수정
- [ ] 문서 수정
- [x] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [x] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

<br>

## 🙋 리뷰 요구 사항
- users 테이블에 image 칼럼도 삭제 하겠습니다.
- 추후 로그인/로그아웃 버튼 위치 논의 하고 싶습니다.
- 프로필도 맞추어 수정해야 할 것 같습니다!
- 관련 트러블슈팅도 위에 올려두었습니다!

<br>

## ❗ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.  Commit message convention 참고  (Ctrl  + 클릭하세요.) 
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
