### PR TITLE
[랜딩페이지]재난 알림 배너 구현 성공

### DIFF
--- a/src/app/api/fetchDisasterAlert.ts
+++ b/src/app/api/fetchDisasterAlert.ts
@@ -10,15 +10,16 @@ const fetchDisasterAlert = async (): Promise<DisasterAlert[]> => {
   const res = await axios.get(apiBase, {
     params: {
       serviceKey: apiKey,
+      pageNo: 30, //30페이지부터 최신 데이터 (추후에 자동으로 최신화 방법 찾기)
       returnType: "json",
-      numOfRows: 10,
+      numOfRows: 1000,
     },
   });
 
   const items = res.data.body;
   if (!Array.isArray(items)) throw new Error("데이터 형식 오류");
 
-  return items
+  const filtered = items
     .filter(item => item.DST_SE_NM !== "기타")
     .map(item => ({
       id: item.SN,
@@ -26,7 +27,10 @@ const fetchDisasterAlert = async (): Promise<DisasterAlert[]> => {
       createdAt: item.CRT_DT,
       region: item.RCPTN_RGN_NM,
       disasterType: item.DST_SE_NM,
-    }));
+    }))
+    .sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime());
+
+  return filtered;
 };
 
 export default fetchDisasterAlert;

--- a/src/app/api/fetchDisasterAlert.ts
+++ b/src/app/api/fetchDisasterAlert.ts
@@ -1,0 +1,33 @@
+"use server";
+
+import axios from "axios";
+
+const fetchDisasterAlert = async (): Promise<[]> => {
+    const apiKey = process.env.NEXT_DISASTER_API_KEY!;
+    const apiBase = process.env.NEXT_DISASTER_API_BASE_URL!;
+  
+    const res = await axios.get(apiBase, {
+      params: {
+        serviceKey: apiKey,
+        returnType: "json",
+        numOfRows: 10,
+      },
+    });
+  
+    const items = res.data.body;
+    if (!Array.isArray(items)) throw new Error("데이터 형식 오류");
+  
+  
+    return items
+    .filter(item => item.DST_SE_NM !== "기타")
+    .map(item => ({
+      id: item.SN,
+      message: item.MSG_CN,
+      createdAt: item.CRT_DT,
+      region: item.RCPTN_RGN_NM,
+      disasterType: item.DST_SE_NM,
+    }));
+  };
+  
+  export default fetchDisasterAlert;
+  

--- a/src/app/api/fetchDisasterAlert.ts
+++ b/src/app/api/fetchDisasterAlert.ts
@@ -1,24 +1,24 @@
 "use server";
 
 import axios from "axios";
+import { DisasterAlert } from "@/types/disaster";
 
-const fetchDisasterAlert = async (): Promise<[]> => {
-    const apiKey = process.env.NEXT_DISASTER_API_KEY!;
-    const apiBase = process.env.NEXT_DISASTER_API_BASE_URL!;
-  
-    const res = await axios.get(apiBase, {
-      params: {
-        serviceKey: apiKey,
-        returnType: "json",
-        numOfRows: 10,
-      },
-    });
-  
-    const items = res.data.body;
-    if (!Array.isArray(items)) throw new Error("데이터 형식 오류");
-  
-  
-    return items
+const fetchDisasterAlert = async (): Promise<DisasterAlert[]> => {
+  const apiKey = process.env.NEXT_DISASTER_API_KEY!;
+  const apiBase = process.env.NEXT_DISASTER_API_BASE_URL!;
+
+  const res = await axios.get(apiBase, {
+    params: {
+      serviceKey: apiKey,
+      returnType: "json",
+      numOfRows: 10,
+    },
+  });
+
+  const items = res.data.body;
+  if (!Array.isArray(items)) throw new Error("데이터 형식 오류");
+
+  return items
     .filter(item => item.DST_SE_NM !== "기타")
     .map(item => ({
       id: item.SN,
@@ -27,7 +27,6 @@ const fetchDisasterAlert = async (): Promise<[]> => {
       region: item.RCPTN_RGN_NM,
       disasterType: item.DST_SE_NM,
     }));
-  };
-  
-  export default fetchDisasterAlert;
-  
+};
+
+export default fetchDisasterAlert;

--- a/src/components/landing/AlertBanner.tsx
+++ b/src/components/landing/AlertBanner.tsx
@@ -1,9 +1,45 @@
 "use client";
 
-import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { AlertTriangle } from "lucide-react";
 import { useQuery } from "@tanstack/react-query";
 import fetchDisasterAlert from "@/app/api/fetchDisasterAlert";
+
+// 색상 테마 매핑 함수
+const getTheme = (type: string) => {
+  const severeTypes = ["지진", "태풍", "해일"];
+  const warningTypes = ["호우", "강풍", "폭염"];
+
+  if (severeTypes.includes(type)) {
+    return {
+      bg: "bg-red-50",
+      border: "border-red-500",
+      text: "text-red-800",
+      icon: "text-red-600",
+      sub: "text-red-500",
+      iconBg: "bg-red-100",
+    };
+  }
+
+  if (warningTypes.includes(type)) {
+    return {
+      bg: "bg-amber-50",
+      border: "border-amber-500",
+      text: "text-amber-800",
+      icon: "text-amber-600",
+      sub: "text-amber-500",
+      iconBg: "bg-amber-100",
+    };
+  }
+
+  return {
+    bg: "bg-gray-50",
+    border: "border-gray-300",
+    text: "text-gray-800",
+    icon: "text-gray-600",
+    sub: "text-gray-500",
+    iconBg: "bg-gray-100",
+  };
+};
 
 const AlertBanner = () => {
   const {
@@ -13,33 +49,29 @@ const AlertBanner = () => {
   } = useQuery({
     queryKey: ["disaster-alerts"],
     queryFn: fetchDisasterAlert,
-    refetchInterval: 1000 * 60, // 1분마다 새로고침
+    refetchInterval: 1000 * 60,
   });
 
   const alert = alerts?.[0];
   if (isLoading || error || !alert) return null;
 
-  return (
-    <div className="w-full px-5 sm:px-[20px]">
-      <Alert
-        variant="destructive"
-        className="flex w-full flex-row items-start gap-4 rounded-xl border border-red-500 bg-red-50 px-4 py-3 shadow-md"
-      >
-        {/* 아이콘 */}
-        <div className="flex-shrink-0 pt-1">
-          <AlertTriangle className="h-5 w-5 text-red-600" />
-        </div>
+  const theme = getTheme(alert.disasterType);
 
-        {/* 텍스트 */}
-        <div className="flex min-w-0 flex-1 flex-col break-words">
-          <AlertTitle className="line-clamp-none break-words whitespace-pre-wrap">
-            {alert.message}
-          </AlertTitle>
-          <AlertDescription className="mt-1 w-full text-sm break-words whitespace-pre-wrap text-red-500">
-            [{alert.region}] · {alert.createdAt}
-          </AlertDescription>
-        </div>
-      </Alert>
+  return (
+    <div
+      className={`mx-20px flex items-center gap-4 rounded-xl border ${theme.border} ${theme.bg} px-5 py-4 shadow-md transition-all duration-300`}
+    >
+      <div
+        className={`flex h-10 w-10 items-center justify-center rounded-full ${theme.iconBg} ${theme.icon}`}
+      >
+        <AlertTriangle className="h-5 w-5" />
+      </div>
+      <div className={`flex flex-col ${theme.text}`}>
+        <p className="text-base leading-snug font-semibold">{alert.message}</p>
+        <p className={`text-sm ${theme.sub} mt-1`}>
+          {alert.region} · {alert.createdAt}
+        </p>
+      </div>
     </div>
   );
 };

--- a/src/components/landing/AlertBanner.tsx
+++ b/src/components/landing/AlertBanner.tsx
@@ -20,14 +20,27 @@ const AlertBanner = () => {
   if (isLoading || error || !alert) return null;
 
   return (
-    <Alert variant="destructive" className="mx-20px">
-      <AlertTriangle className="mr-2 h-4 w-4" />
-      <AlertTitle>{alert.message}</AlertTitle>
-      <AlertDescription>
-        [ {alert.region}]
-         {alert.createdAt}
-      </AlertDescription>
-    </Alert>
+    <div className="w-full px-5 sm:px-[20px]">
+      <Alert
+        variant="destructive"
+        className="flex w-full flex-row items-start gap-4 rounded-xl border border-red-500 bg-red-50 px-4 py-3 shadow-md"
+      >
+        {/* 아이콘 */}
+        <div className="flex-shrink-0 pt-1">
+          <AlertTriangle className="h-5 w-5 text-red-600" />
+        </div>
+
+        {/* 텍스트 */}
+        <div className="flex min-w-0 flex-1 flex-col break-words">
+          <AlertTitle className="line-clamp-none break-words whitespace-pre-wrap">
+            {alert.message}
+          </AlertTitle>
+          <AlertDescription className="mt-1 w-full text-sm break-words whitespace-pre-wrap text-red-500">
+            [{alert.region}] · {alert.createdAt}
+          </AlertDescription>
+        </div>
+      </Alert>
+    </div>
   );
 };
 

--- a/src/components/landing/AlertBanner.tsx
+++ b/src/components/landing/AlertBanner.tsx
@@ -49,7 +49,7 @@ const AlertBanner = () => {
   } = useQuery({
     queryKey: ["disaster-alerts"],
     queryFn: fetchDisasterAlert,
-    refetchInterval: 1000 * 60,
+    refetchInterval: 1000 * 60, // 1분마다 새로고침
   });
 
   const alert = alerts?.[0];

--- a/src/components/landing/AlertBanner.tsx
+++ b/src/components/landing/AlertBanner.tsx
@@ -1,15 +1,34 @@
-import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert"
-import { AlertTriangle } from "lucide-react"
+"use client";
+
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { AlertTriangle } from "lucide-react";
+import { useQuery } from "@tanstack/react-query";
+import fetchDisasterAlert from "@/app/api/fetchDisasterAlert";
 
 const AlertBanner = () => {
+  const {
+    data: alerts,
+    isLoading,
+    error,
+  } = useQuery({
+    queryKey: ["disaster-alerts"],
+    queryFn: fetchDisasterAlert,
+    refetchInterval: 1000 * 60, // 1분마다 새로고침
+  });
 
-    return (
-        <Alert variant="destructive" className="mx-20px" >
-            <AlertTriangle />
-            <AlertTitle>[지진] 서울 강서구 규모 4.0 지진 발생</AlertTitle>
-            <AlertDescription>부가 설명</AlertDescription>
-        </Alert>
-    )
-}
+  const alert = alerts?.[0];
+  if (isLoading || error || !alert) return null;
 
-export default AlertBanner
+  return (
+    <Alert variant="destructive" className="mx-20px">
+      <AlertTriangle className="mr-2 h-4 w-4" />
+      <AlertTitle>{alert.message}</AlertTitle>
+      <AlertDescription>
+        [ {alert.region}]
+         {alert.createdAt}
+      </AlertDescription>
+    </Alert>
+  );
+};
+
+export default AlertBanner;

--- a/src/types/disaster.ts
+++ b/src/types/disaster.ts
@@ -1,0 +1,7 @@
+export interface DisasterAlert {
+    id: string;
+    message: string;
+    createdAt: string;
+    region: string;
+    disasterType: string;
+  }


### PR DESCRIPTION
## 💡 이슈 번호
#155 

<br>

## 📜 작업 설명
- 재난 문자 api로 실시간 재난 현황 받아오기
- 재난 구분 "기타"는 필터링
- 데이터 최신순으로 sort
- 배너 디자인 과정에서 타이틀 메세지가 계속해서 잘리는 이슈로 shadcn/ alert 컴포넌트 제거 (추후 디자인 변경 시 다시 적용 예정)
- 재난 상황에 따라 배너의 전체적인 색을 조건부 적용 

<br>

## 🖼️ 미리보기
<img width="324" alt="스크린샷 2025-04-15 오전 2 04 23" src="https://github.com/user-attachments/assets/af021f5a-cbc0-44a3-bf20-904615684d33" />



<br>

## 📜 PR 유형
작업한 내용 확인 및 체크

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [x] CSS 등 사용자 UI 디자인 변경
- [x] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [x] 주석 추가 및 수정
- [x] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

<br>

## 🙋 리뷰 요구 사항
- 디자인은 디자이너님과 의논 후 최종 변경 하겠습니다

<br>

## ❗ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.  Commit message convention 참고  (Ctrl  + 클릭하세요.) 
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
