### PR TITLE
[지도페이지]지오로케이션으로 위치 받아서 주변 대피소 반경 대폭 확대

### DIFF
--- a/src/components/map/CrosshairButton.tsx
+++ b/src/components/map/CrosshairButton.tsx
@@ -15,7 +15,7 @@ const CrosshairButton = () => {
     mutate(undefined, {
       onSuccess: data => {
         setCenter(data);
-        setLevel(3);
+        setLevel(7);
         setCurrentLocation(data);
       },
     });

--- a/src/components/map/ShelterList.tsx
+++ b/src/components/map/ShelterList.tsx
@@ -80,7 +80,7 @@ const ShelterList = ({ isDrawerOpen, shelters, sortBy }: ShelterListProps) => {
 
                     {typeof shelter.distance === "number" && (
                       <span className="flex items-center text-sm font-normal text-[#666666]">
-                        {(shelter.distance / 1000).toFixed(1)} km
+                        {(shelter.distance / 1000).toFixed(1)} km 
                       </span>
                     )}
                   </div>


### PR DESCRIPTION


<br>

## 📜 작업 설명
지오로케이션으로 거리를 받아왔을때 기존 지도축소레벨 3에서 7로 훨씬 먼 곳의 대피소까지 보이게 했습니다.
15-20km의 대피소까지 나오는 것 같습니다